### PR TITLE
Fix syntax error

### DIFF
--- a/eKomi/Order.php
+++ b/eKomi/Order.php
@@ -66,7 +66,7 @@ class Order
     }
     
     
-    public function setReviewLink($reviewLink() {
+    public function setReviewLink($reviewLink) {
         $this->reviewLink = $reviewLink;
         return $this;
     }


### PR DESCRIPTION
Extraneous paren breaks class definition